### PR TITLE
Add indexes and other refactorings

### DIFF
--- a/plugin/BTCPayServer.Plugins.Strike.csproj
+++ b/plugin/BTCPayServer.Plugins.Strike.csproj
@@ -36,6 +36,7 @@
 		<ProjectReference Include="..\submodules\btcpayserver\BTCPayServer\BTCPayServer.csproj" />
 		<ProjectReference Include="..\submodules\strike-client\src\Strike.Client\Strike.Client.csproj">
 			<Private>true</Private>
+			<ExcludeAssets></ExcludeAssets>
 		</ProjectReference>
 	</ItemGroup>
 

--- a/plugin/BTCPayServer.Plugins.Strike.csproj
+++ b/plugin/BTCPayServer.Plugins.Strike.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>10</LangVersion>
+		<LangVersion>11</LangVersion>
 	</PropertyGroup>
 
 	<!-- Plugin specific properties -->

--- a/plugin/Migrations/20240715155402_AddIndexes.cs
+++ b/plugin/Migrations/20240715155402_AddIndexes.cs
@@ -1,0 +1,30 @@
+﻿using BTCPayServer.Plugins.Strike.Persistence;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.Plugins.Strike.Migrations
+{
+	[DbContext(typeof(StrikeDbContext))]
+	[Migration("20240715155402_AddIndexes")]
+	public partial class AddIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+			migrationBuilder.Sql("""
+CREATE INDEX idx_quotes_not_observed ON "BTCPayServer.Plugins.Strike"."Quotes"("TenantId") WHERE NOT("Observed");
+CREATE INDEX idx_quotes_paymenthash ON "BTCPayServer.Plugins.Strike"."Quotes"("PaymentHash");
+CREATE INDEX idx_quotes_invoiceid ON "BTCPayServer.Plugins.Strike"."Quotes"("InvoiceId");
+CREATE INDEX idx_payments_tenantid_paymenthash ON "BTCPayServer.Plugins.Strike"."Payments"("TenantId","PaymentHash");
+""");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            
+        }
+    }
+}

--- a/plugin/Migrations/20240715155402_AddIndexes.cs
+++ b/plugin/Migrations/20240715155402_AddIndexes.cs
@@ -14,9 +14,11 @@ namespace BTCPayServer.Plugins.Strike.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
 			migrationBuilder.Sql("""
+ALTER TABLE "BTCPayServer.Plugins.Strike"."Quotes" DROP CONSTRAINT "PK_Quotes";
+ALTER TABLE "BTCPayServer.Plugins.Strike"."Quotes" DROP COLUMN "Id";
+ALTER TABLE "BTCPayServer.Plugins.Strike"."Quotes" ADD CONSTRAINT "PK_Quotes" PRIMARY KEY("InvoiceId");
 CREATE INDEX idx_quotes_not_observed ON "BTCPayServer.Plugins.Strike"."Quotes"("TenantId") WHERE NOT("Observed");
 CREATE INDEX idx_quotes_paymenthash ON "BTCPayServer.Plugins.Strike"."Quotes"("PaymentHash");
-CREATE INDEX idx_quotes_invoiceid ON "BTCPayServer.Plugins.Strike"."Quotes"("InvoiceId");
 CREATE INDEX idx_payments_tenantid_paymenthash ON "BTCPayServer.Plugins.Strike"."Payments"("TenantId","PaymentHash");
 """);
         }

--- a/plugin/Migrations/StrikeDbContextModelSnapshot.cs
+++ b/plugin/Migrations/StrikeDbContextModelSnapshot.cs
@@ -90,11 +90,9 @@ namespace BTCPayServer.Plugins.Strike.Migrations
 
             modelBuilder.Entity("BTCPayServer.Plugins.Strike.Persistence.StrikeQuote", b =>
                 {
-                    b.Property<long>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bigint");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<long>("Id"));
+                    b.Property<string>("InvoiceId")
+                        .HasMaxLength(300)
+                        .HasColumnType("character varying(300)");
 
                     b.Property<decimal>("ConversionRate")
                         .HasColumnType("numeric");
@@ -108,11 +106,6 @@ namespace BTCPayServer.Plugins.Strike.Migrations
 
                     b.Property<DateTimeOffset>("ExpiresAt")
                         .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("InvoiceId")
-                        .IsRequired()
-                        .HasMaxLength(300)
-                        .HasColumnType("character varying(300)");
 
                     b.Property<string>("LightningInvoice")
                         .IsRequired()
@@ -152,7 +145,7 @@ namespace BTCPayServer.Plugins.Strike.Migrations
                         .HasMaxLength(300)
                         .HasColumnType("character varying(300)");
 
-                    b.HasKey("Id");
+                    b.HasKey("InvoiceId");
 
                     b.ToTable("Quotes", "BTCPayServer.Plugins.Strike");
                 });

--- a/plugin/Persistence/StrikeQuote.cs
+++ b/plugin/Persistence/StrikeQuote.cs
@@ -6,8 +6,6 @@ using Strike.Client.Models;
 namespace BTCPayServer.Plugins.Strike.Persistence;
 public class StrikeQuote : IHasTenantId
 {
-	public long Id { get; init; }
-
 	public string TenantId { get; set; } = string.Empty;
 
 	public string InvoiceId { get; init; } = string.Empty;
@@ -61,8 +59,7 @@ public class StrikeQuoteConfiguration : IEntityTypeConfiguration<StrikeQuote>
 	public void Configure(EntityTypeBuilder<StrikeQuote> builder)
 	{
 		builder.ToTable("Quotes");
-		builder.Property(x => x.Id).ValueGeneratedOnAdd();
-		builder.HasKey(x => x.Id);
+		builder.HasKey(x => x.InvoiceId);
 
 		builder.Property(x => x.TenantId).HasMaxLength(300);
 		builder.Property(x => x.InvoiceId).HasMaxLength(300);

--- a/plugin/StrikeLightningClient.Receiving.cs
+++ b/plugin/StrikeLightningClient.Receiving.cs
@@ -178,9 +178,8 @@ public partial class StrikeLightningClient
 			await using var db = _dbContextFactory.CreateContext();
 			
 			var invoiceId = invoice.InvoiceId.ToString();
-			var quote = await db.Quotes
-				.FirstOrDefaultAsync(x => x.TenantId == _tenantId && x.InvoiceId == invoiceId);
-			if (quote == null)
+			var quote = await db.Quotes.FindAsync(invoiceId);
+			if (quote == null || quote.TenantId != _tenantId)
 				return null;
 
 			var converted = ConvertInvoice(invoice, quote);

--- a/plugin/StrikeLightningClient.Sending.cs
+++ b/plugin/StrikeLightningClient.Sending.cs
@@ -61,7 +61,7 @@ public partial class StrikeLightningClient
 	public async Task<LightningPayment[]> ListPayments(ListPaymentsParams? request, CancellationToken cancellation = new())
 	{
 		await using var db = _dbContextFactory.CreateContext();
-		var payments = await GetPayments(db, _tenantId, request?.IncludePending == false, (int?)request?.OffsetIndex ?? 0);
+		var payments = await GetPayments(db, request?.IncludePending == false, (int?)request?.OffsetIndex ?? 0);
 		return payments
 			.Select(x => new LightningPayment
 			{
@@ -78,7 +78,7 @@ public partial class StrikeLightningClient
 	
 	
 
-	public async Task<StrikePayment[]> GetPayments(StrikeDbContext db, string tenantId, bool onlyCompleted, int offset = 0)
+	public async Task<StrikePayment[]> GetPayments(StrikeDbContext db, bool onlyCompleted, int offset = 0)
 	{
 		return await db.Payments
 			.Where(x => x.TenantId == _tenantId)

--- a/plugin/StrikeLightningClient.cs
+++ b/plugin/StrikeLightningClient.cs
@@ -23,9 +23,10 @@ public partial class StrikeLightningClient : ILightningClient
 	private readonly ILogger _logger;
 	private readonly Currency _convertToCurrency;
 	private readonly string _tenantId;
+	private readonly EventAggregator _eventAggregator;
 
 	public StrikeLightningClient(StrikeClient client, StrikeDbContextFactory dbContextFactory, 
-		Network network, ILogger logger, Currency convertToCurrency, string tenantId)
+		Network network, ILogger logger, Currency convertToCurrency, string tenantId, EventAggregator eventAggregator)
 	{
 		_client = client;
 		_dbContextFactory = dbContextFactory;
@@ -33,6 +34,7 @@ public partial class StrikeLightningClient : ILightningClient
 		_logger = logger;
 		_convertToCurrency = convertToCurrency;
 		_tenantId = tenantId;
+		_eventAggregator = eventAggregator;
 	}
 
 	public override string ToString()

--- a/plugin/StrikeLightningConnectionStringHandler.cs
+++ b/plugin/StrikeLightningConnectionStringHandler.cs
@@ -17,11 +17,13 @@ public class StrikeLightningConnectionStringHandler : ILightningConnectionString
 {
 	private readonly IServiceProvider _serviceProvider;
 	private readonly ILoggerFactory _loggerFactory;
+	private readonly EventAggregator _eventAggregator;
 
-	public StrikeLightningConnectionStringHandler(IServiceProvider serviceProvider, ILoggerFactory loggerFactory)
+	public StrikeLightningConnectionStringHandler(IServiceProvider serviceProvider, ILoggerFactory loggerFactory, EventAggregator eventAggregator)
 	{
 		_serviceProvider = serviceProvider;
 		_loggerFactory = loggerFactory;
+		_eventAggregator = eventAggregator;
 	}
 
 	public ILightningClient? Create(string connectionString, Network network, out string? error)
@@ -105,7 +107,7 @@ public class StrikeLightningConnectionStringHandler : ILightningConnectionString
 		var logger = _loggerFactory.CreateLogger<StrikeLightningClient>();
 		var dbContextFactory = _serviceProvider.GetRequiredService<StrikeDbContextFactory>();
 		
-		holder.AddOrUpdateClient(tenantId, new StrikeLightningClient(client, dbContextFactory, network, logger, convertToCurrency, tenantId));
+		holder.AddOrUpdateClient(tenantId, new StrikeLightningClient(client, dbContextFactory, network, logger, convertToCurrency, tenantId, _eventAggregator));
 		return holder.GetClient(tenantId);
 	}
 

--- a/plugin/StrikePluginHostedService.cs
+++ b/plugin/StrikePluginHostedService.cs
@@ -108,7 +108,7 @@ public class StrikePluginHostedService : EventHostedServiceBase, IDisposable
 		await using var db = _dbContextFactory.CreateContext();
 		foreach (var invoice in invoices.Where(a => a.State == InvoiceState.Paid))
 		{
-			var quote = await db.Quotes.SingleOrDefaultAsync(a => a.InvoiceId == invoice.InvoiceId.ToString());
+			var quote = await db.Quotes.FindAsync(invoice.InvoiceId.ToString());
 			if (quote == null)
 				continue;
 
@@ -145,7 +145,7 @@ public class StrikePluginHostedService : EventHostedServiceBase, IDisposable
 		foreach (var invoice in invoices.Where(a => 
 			         a.State is InvoiceState.Canceled or InvoiceState.Reversed or InvoiceState.Undefined))
 		{
-				var quote = await db.Quotes.SingleOrDefaultAsync(a => a.InvoiceId == invoice.InvoiceId.ToString());
+				var quote = await db.Quotes.FindAsync(invoice.InvoiceId.ToString());
 				if (quote == null)
 					continue;
 
@@ -182,7 +182,7 @@ public class StrikePluginHostedService : EventHostedServiceBase, IDisposable
 			if (pm?.GetPaymentMethodDetails() is LightningLikePaymentMethodDetails lightning)
 			{
 				await using var db = _dbContextFactory.CreateContext();
-				var quote = await db.Quotes.SingleOrDefaultAsync(a => a.InvoiceId == lightning.InvoiceId, cancellationToken: cancellationToken);
+				var quote = await db.Quotes.FindAsync(new[] { lightning.InvoiceId }, cancellationToken: cancellationToken);
 				if (quote != null)
 				{
 					quote.Observed = true;

--- a/plugin/StrikePluginHostedService.cs
+++ b/plugin/StrikePluginHostedService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -16,6 +16,8 @@ using Strike.Client.Invoices;
 using Strike.Client.Models;
 
 namespace BTCPayServer.Plugins.Strike;
+
+public record StrikePaidInvoice(string TenantId, Invoice Invoice);
 
 public class StrikePluginHostedService : EventHostedServiceBase, IDisposable
 {
@@ -114,7 +116,7 @@ public class StrikePluginHostedService : EventHostedServiceBase, IDisposable
 
 			// saving changes so that invoice listener can immediately pick up on this
 			await db.SaveChangesAsync();
-
+			EventAggregator.Publish(new StrikePaidInvoice(quote.TenantId, invoice));
 			// PROCESS CURRENCY CONVERSION
 			if (quote.PaidConvertTo != null)
 			{


### PR DESCRIPTION
This PR:
1. Remove some deadcode
2. Notify the strike listener from the hosted service via the EventAggregator rather than relying on polling.

This is done because if had 30 stores with strikes, you would end up with 30 requests every seconds polling the database which isn't a good idea.

3. Adding indexes

While it should scale most of the queries the plugin is doing, the `ListPayments` will still be more and more slow. But I don't think we really use it.

4. Removing useless column

There is a useless column in Quotes, I removed it and made InvoiceId a primary key.
